### PR TITLE
Fix default config

### DIFF
--- a/conf_files/huntsman.yaml
+++ b/conf_files/huntsman.yaml
@@ -40,7 +40,7 @@ cameras:
     hdr_mode: True
     auto_detect: False
     devices:
-        model: sbig
+    -   model: sbig
         port: 83F011791
         set_point: 0
         filter_type: r2_1


### PR DESCRIPTION
`devices` should be a list.

True fix for problem reported in https://github.com/panoptes/POCS/pull/226. That PR seemed to fix it because it moved all `camera_config` access to inside an `if/else` that was never triggered. 

Error I was seeing was:
```
AttributeError                            Traceback (most recent call last)                                                                                                                                                                   
<ipython-input-2-118124dbcae3> in <module>()                                                                                                                                                                                                  
----> 1 obs = HuntsmanObservatory(simulator=['weather', 'camera', 'night'])                                                                                                                                                                   
                                                                                                                                                                                                                                              
/storage/Projects/AstroHuntsman/huntsman-pocs/huntsman/observatory.py in __init__(self, with_autoguider, hdr_mode, take_flats, *args, **kwargs)                                                                                               
     47             sys.exit("Must set HUNTSMAN_POCS variable")                                                                                                                                                                               
     48                                                                                                                                                                                                                                       
---> 49         super().__init__(config=self._load_config(), *args, **kwargs)                                                                                                                                                                 
     50                                                                    
     51         self._has_hdr_mode = hdr_mode                           
                                                                                        
/storage/panoptes/POCS/pocs/observatory.py in __init__(self, *args, **kwargs)
     48         self.cameras = OrderedDict()                                                                                                                                                                                                       49         self._primary_camera = None                                                                                    
---> 50         self._create_cameras(**kwargs)                                                                                 
     51                                                                     
     52         self.logger.info('\tSetting up scheduler')                      
                                                                             
/storage/panoptes/POCS/pocs/observatory.py in _create_cameras(self, **kwargs)           
    617                 camera_readout = 0.5                                                    
    618                                                                                                  
--> 619             camera_set_point = camera_config.get('set_point', None)
    620             camera_filter = camera_config.get('filter_type', None)
    621             
                                                                    
AttributeError: 'str' object has no attribute 'get'

```